### PR TITLE
make sure the response stream ends

### DIFF
--- a/cgi.js
+++ b/cgi.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -130,6 +129,11 @@ function cgi(cgiBin, options) {
 
         // The response body is piped to the response body of the HTTP request
         cgiResult.pipe(res);
+        
+        // make sure the response stream ends when process exit
+        cgiSpawn.stdout.on('close', function(){
+          res.end();
+        });
       });
     } else {
       // If it's an NPH script, then responsibility of the HTTP response is


### PR DESCRIPTION
hi, Nathan,

as I was using your module `node-gitweb`, I came into an [issue](https://github.com/TooTallNate/node-gitweb/issues/4). When I keep refreshing the browser I found it sometimes happens. So I add this line, and it works fine, without any negative impact.
