### PR TITLE
send a response if the cgi script failed

### DIFF
--- a/cgi.js
+++ b/cgi.js
@@ -105,6 +105,14 @@ function cgi(cgiBin, options) {
     var cgiSpawn = spawn(cgiBin, options.args, options);
     debug('cgi spawn (pid: %d)', cgiSpawn.pid);
 
+    var exited = false;
+
+    if (options.timeout) {
+      setTimeout(function() {
+        if (!exited) cgiSpawn.kill();
+      }, options.timeout * 1000);
+    }
+
     // The request body is piped to 'stdin' of the CGI spawn
     req.pipe(cgiSpawn.stdin);
 
@@ -148,6 +156,7 @@ function cgi(cgiBin, options) {
 
     cgiSpawn.on('exit', function(code, signal) {
       debug('cgi spawn %d "exit" event (code %s) (signal %s)', cgiSpawn.pid, code, signal);
+      exited = true;
       // TODO: react on a failure status code (dump stderr to the response?)
     });
 

--- a/cgi.js
+++ b/cgi.js
@@ -156,6 +156,11 @@ function cgi(cgiBin, options) {
       debug('cgi spawn %d stdout "end" event', cgiSpawn.pid);
       if (cgiResult) {
         cgiResult.cleanup();
+        if (!res.headersSent) {
+          res.writeHead(500, { 'Content-type': 'text/plain' });
+          res.write('Internal Server Error');
+          res.end();
+        }
       }
       if (onData) {
         options.stderr.removeListener('data', onData);


### PR DESCRIPTION
Currently, if a CGI script exits before generating any output, the HTTP response hangs. This PR fixes that by inspecting `res.headersSent` at the end of the request, and if they have not been sent, sends a generic 500 status response. 

There might well be a better way to handle this, but not without going more into the depths of `stream-stack` than I have time for right now.
