### PR TITLE
Adding an option to kill the cgi process when a request aborts permaturely

### DIFF
--- a/cgi.js
+++ b/cgi.js
@@ -107,6 +107,10 @@ function cgi(cgiBin, options) {
     var cgiSpawn = spawn(cgiBin, opts.args, opts);
     debug('cgi spawn (pid: %o)', cgiSpawn.pid);
 
+    if (options.killOnDisconnect) {
+      req.on('close', function() { cgiSpawn.kill(); });  
+    }
+
     // The request body is piped to 'stdin' of the CGI spawn
     req.pipe(cgiSpawn.stdin);
 
@@ -170,6 +174,8 @@ cgi.DEFAULTS = {
   env: {},
   // Set to 'true' if the CGI script is an NPH script
   nph: false,
+  // kill the cgi script if the request abort
+  killOnDisconnect: false,
   // Set to a `Stream` instance if you want to log stderr of the CGI script somewhere
   stderr: null,
   // A list of arguments for the cgi bin to be used by spawn

--- a/cgi.js
+++ b/cgi.js
@@ -104,26 +104,26 @@ function cgi(cgiBin, options) {
     debug('env: %o', env);
     opts.env = env;
 
+    if (options.nph && options.dupfd) {
+        opts.stdio= [req.connection, req.connection, 'inherit'];
+    }
+    
     var cgiSpawn = spawn(cgiBin, opts.args, opts);
     debug('cgi spawn (pid: %o)', cgiSpawn.pid);
-
-    if (options.killOnDisconnect) {
-      req.on('close', function() { cgiSpawn.kill(); });  
-    }
-
+    
     // The request body is piped to 'stdin' of the CGI spawn
-    req.pipe(cgiSpawn.stdin);
-
-    // If `options.stderr` is set to a Stream instance, then re-emit the
-    // 'data' events onto the stream.
-    if (options.stderr) {
-      cgiSpawn.stderr.pipe(options.stderr);
-    }
-
-    // A proper CGI script is supposed to print headers to 'stdout'
-    // followed by a blank line, then a response body.
-    var cgiResult;
     if (!options.nph) {
+      req.pipe(cgiSpawn.stdin);
+
+      // If `options.stderr` is set to a Stream instance, then re-emit the
+      // 'data' events onto the stream.
+      if (options.stderr) {
+        cgiSpawn.stderr.pipe(options.stderr);
+      }
+
+      // A proper CGI script is supposed to print headers to 'stdout'
+      // followed by a blank line, then a response body.
+      var cgiResult;
       cgiResult = new CGIParser(cgiSpawn.stdout);
 
       // When the blank line after the headers has been parsed, then
@@ -142,28 +142,43 @@ function cgi(cgiBin, options) {
         // The response body is piped to the response body of the HTTP request
         cgiResult.pipe(res);
       });
+      
+      cgiSpawn.stdout.on('end', function () {
+        // clean up event listeners upon the "end" event
+        debug('cgi spawn %o stdout "end" event', cgiSpawn.pid);
+        if (cgiResult) {
+          cgiResult.cleanup();
+        }
+        //if (options.stderr) {
+        //  cgiSpawn.stderr.unpipe(options.stderr);
+        //}
+      });
+
     } else {
       // If it's an NPH script, then responsibility of the HTTP response is
       // completely passed off to the child process.
-      cgiSpawn.stdout.pipe(res.connection);
+    
+      if (options.dupfd) {
+        // Close the connection because it is now handled by the child
+        req.connection.destroy();
+      } else {
+        req.pipe(cgiSpawn.stdin);
+        // Setup pipes
+        cgiSpawn.stdout.pipe(res.connection);
+        
+        // If `options.stderr` is set to a Stream instance, then re-emit the
+        // 'data' events onto the stream.
+        if (options.stderr) {
+          cgiSpawn.stderr.pipe(options.stderr);
+        }
+      }
     }
 
     cgiSpawn.on('exit', function(code, signal) {
       debug('cgi spawn %o "exit" event (code %o) (signal %o)', cgiSpawn.pid, code, signal);
       // TODO: react on a failure status code (dump stderr to the response?)
     });
-
-    cgiSpawn.stdout.on('end', function () {
-      // clean up event listeners upon the "end" event
-      debug('cgi spawn %o stdout "end" event', cgiSpawn.pid);
-      if (cgiResult) {
-        cgiResult.cleanup();
-      }
-      //if (options.stderr) {
-      //  cgiSpawn.stderr.unpipe(options.stderr);
-      //}
-    });
-  };
+  }
 }
 
 // The default config options to use for each `cgi()` call.
@@ -174,10 +189,10 @@ cgi.DEFAULTS = {
   env: {},
   // Set to 'true' if the CGI script is an NPH script
   nph: false,
-  // kill the cgi script if the request abort
-  killOnDisconnect: false,
   // Set to a `Stream` instance if you want to log stderr of the CGI script somewhere
   stderr: null,
+  // Pass file descriptors of connection to the child (no copy). Probably only work with http connections
+  dupfd: false,
   // A list of arguments for the cgi bin to be used by spawn
   args: []
 };


### PR DESCRIPTION
This is usefull to reduce resource consumption for cgi that can be aborted (in my case, cgi that transcode large images)  