### PR TITLE
Add error handling when parsing headers

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -19,6 +19,7 @@ function Parser(stream) {
     allowFoldedHeaders: false
   });
   this._headerParser.on('headers', this._onHeadersComplete.bind(this));
+  this._headerParser.on('error', this._onHeadersError.bind(this));
 }
 require('util').inherits(Parser, StreamStack);
 module.exports = Parser;
@@ -37,4 +38,8 @@ Parser.prototype._onHeadersComplete = function(headers, leftover) {
   if (leftover) {
     this._onData(leftover);
   }
+}
+
+Parser.prototype._onHeadersError = function(err) {
+  this.emit('error', err);
 }


### PR DESCRIPTION
If the headers are malformed in the current release then an uncaught exception is thrown causing everything to crash. This adds an error handler that catches errors from the headers parser. The error is sent to stderr if it stderr is set. Nothing is sent to the client from cgi-node. The Stream.write method of stderr can decide what will be sent to the client.

If stderr is not set then the error is thrown and behavior is similar to the current release.